### PR TITLE
Add sigmoid activation to prev_masks

### DIFF
--- a/train.py
+++ b/train.py
@@ -203,6 +203,8 @@ class BaseTrainer:
             multimask_output=False,
         )
         prev_masks = F.interpolate(low_res_masks, size=gt3D.shape[-3:], mode='trilinear', align_corners=False)
+        prev_masks = torch.sigmoid(prev_masks)  
+        
         return low_res_masks, prev_masks
 
     def get_points(self, prev_masks, gt3D):


### PR DESCRIPTION
This pull request introduces a sigmoid activation function to the `prev_masks` in the model. The primary goal of this change is to address a critical issue we encountered during training: without this activation, the model consistently yields a Dice coefficient of zero.